### PR TITLE
Add `convert_arguments` method to plot an Oceananigans.jl `Field` using Makie.jl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docs/src/literated/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 # Manifest.toml
+
+.DS_Store

--- a/examples/LatitudeLongitude_grid.jl
+++ b/examples/LatitudeLongitude_grid.jl
@@ -27,7 +27,7 @@ grid = LatitudeLongitudeGrid(size = (Nx, Ny, Nz),
 
 # Let's create a field. We choose here a field that lives on the ``y``-faces of the cells
 # but any field would do.
-# 
+#
 # We set the field value to ``\cos(3λ)^2 \sin(3φ)`` and see how that looks.
 
 field = YFaceField(grid)
@@ -46,9 +46,10 @@ kwargs = (colorrange = (-1, 1), colormap = :balance)
 fig = Figure()
 ax = Axis(fig[1, 1],
           xlabel="longitude [ᵒ]",
-          ylabel="latitude [ᵒ]")
+          ylabel="latitude [ᵒ]",
+          limits = ((-180, 180), (-90, 90)))
 
-heatmap!(ax, field; kwargs...)
+heatmap!(ax, field, 1; kwargs...)
 
 current_figure() # hide
 fig
@@ -63,7 +64,7 @@ ax = GeoAxis(fig[1, 1],
              coastlines = true,
              lonlims = automatic)
 
-heatmap!(ax, field; kwargs...)
+heatmap!(ax, field, 1; kwargs...)
 
 current_figure() # hide
 fig


### PR DESCRIPTION
This PR removes the exported function `heatmap!` from `Imaginocean` and replaces it with a `Makie.convert_arguments` method to plot an Oceananigans.jl `Field` at some user-specified `depth_level` for any `SurfaceLike` `PlotType` in Makie.jl.  It is not completely finished as there may be a nicer way to extract the longitude, latitude and plotting data (I reused code that was already written to save a bit of time in getting this done). If this way of plotting a `Field` is preferred, will also need to update documentation but I thought before doing all that I would check to see if you approve of this!
Closes #1 